### PR TITLE
Handle local background images without triggering CORS errors

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -130,7 +130,10 @@
   async function loadImage(url) {
     return new Promise((resolve, reject) => {
       const image = new Image();
-      image.crossOrigin = 'anonymous';
+      const isRemoteResource = /^(https?:)?\/\//i.test(url);
+      if (isRemoteResource) {
+        image.crossOrigin = 'anonymous';
+      }
       image.onload = () => resolve(image);
       image.onerror = reject;
       image.src = url;


### PR DESCRIPTION
## Summary
- only set the image crossOrigin flag when loading remote HTTP/S resources
- allow local file and relative background images to load when opening the page from disk

## Testing
- manual

------
https://chatgpt.com/codex/tasks/task_b_68e3361a548883319f76c717d42132a8