### PR TITLE
Permitir configurar opacidade da sobreposição do template

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -280,8 +280,12 @@
       ctx.fillRect(0, 0, W, H);
     }
 
-    ctx.fillStyle = 'rgba(0,0,0,0.45)';
-    ctx.fillRect(0, 0, W, H);
+    const overlayOpacity =
+      typeof THEME.overlayOpacity === 'number' ? THEME.overlayOpacity : 0.45;
+    if (overlayOpacity > 0) {
+      ctx.fillStyle = `rgba(0,0,0,${overlayOpacity})`;
+      ctx.fillRect(0, 0, W, H);
+    }
 
     const textColor = THEME.textOnDark || '#fff';
     ctx.fillStyle = textColor;

--- a/theme.js
+++ b/theme.js
@@ -11,6 +11,7 @@ window.THEME = {
   accent: '#0B3E91',
   accent2: '#1E88E5',
   textOnDark: '#E8c845',
+  overlayOpacity: 0,
 
   layout: {
     photo: {


### PR DESCRIPTION
## Summary
- adiciona ao tema a configuração de opacidade da sobreposição para o fundo
- aplica a camada escura somente quando há opacidade definida acima de zero, preservando o visual do template

## Testing
- Manual

------
https://chatgpt.com/codex/tasks/task_b_68e345c200e88331ad36cef66094bcef