### PR TITLE
Remove hue slider and improve photo adjustments

### DIFF
--- a/index.html
+++ b/index.html
@@ -85,14 +85,11 @@
             <label class="text-xs text-gray-700">Saturação
               <input id="rangeSaturacao" type="range" min="0" max="200" value="100" class="w-full">
             </label>
-            <label class="text-xs text-gray-700">Matiz (Hue)
-              <input id="rangeHue" type="range" min="-180" max="180" value="0" class="w-full">
-            </label>
           </div>
         </div>
         <div class="mt-4 grid grid-cols-1 gap-3">
-          <div class="w-full max-h-96 overflow-hidden rounded-2xl border border-dashed border-gray-300 p-2 bg-gray-50">
-            <img id="cropImg" alt="Pré-visualização para recorte (1:1)" class="max-h-80 mx-auto select-none" />
+          <div id="cropArea" class="w-full max-h-96 min-h-[280px] overflow-hidden rounded-2xl border border-dashed border-gray-300 p-2">
+            <img id="cropImg" alt="Pré-visualização para recorte (1:1)" class="max-h-full mx-auto select-none" />
           </div>
           <div class="flex flex-wrap gap-2">
             <button id="btnZoomIn" class="px-3 py-2 rounded-xl border">Zoom +</button>

--- a/scripts.js
+++ b/scripts.js
@@ -37,7 +37,6 @@
   const rangeBrilho = document.getElementById('rangeBrilho');
   const rangeContraste = document.getElementById('rangeContraste');
   const rangeSaturacao = document.getElementById('rangeSaturacao');
-  const rangeHue = document.getElementById('rangeHue');
 
   const btnZoomIn = document.getElementById('btnZoomIn');
   const btnZoomOut = document.getElementById('btnZoomOut');
@@ -83,12 +82,16 @@
 
   const addTextGap = (value) => value + lineSpacing;
 
+  function readRangeValue(rangeEl, fallback = 100) {
+    const value = Number.parseFloat(rangeEl?.value);
+    return Number.isFinite(value) ? value : fallback;
+  }
+
   function cssFilters() {
-    const brilho = Number(rangeBrilho.value) || 100;
-    const contraste = Number(rangeContraste.value) || 100;
-    const saturacao = Number(rangeSaturacao.value) || 100;
-    const hue = Number(rangeHue.value) || 0;
-    return `brightness(${brilho}%) contrast(${contraste}%) saturate(${saturacao}%) hue-rotate(${hue}deg)`;
+    const brilho = readRangeValue(rangeBrilho, 100);
+    const contraste = readRangeValue(rangeContraste, 100);
+    const saturacao = readRangeValue(rangeSaturacao, 100);
+    return `brightness(${brilho}%) contrast(${contraste}%) saturate(${saturacao}%)`;
   }
 
   function drawSquareWithFilters(img, sizePx, filters) {
@@ -469,7 +472,7 @@
     cropImg.src = url;
   });
 
-  [rangeBrilho, rangeContraste, rangeSaturacao, rangeHue].forEach((el) => {
+  [rangeBrilho, rangeContraste, rangeSaturacao].forEach((el) => {
     el.addEventListener('input', requestRedraw);
   });
 
@@ -489,7 +492,6 @@
     rangeBrilho.value = 100;
     rangeContraste.value = 100;
     rangeSaturacao.value = 100;
-    rangeHue.value = 0;
     cropper?.reset();
     requestRedraw();
   });

--- a/styles.css
+++ b/styles.css
@@ -33,3 +33,30 @@
 #previewBg {
   background: repeating-conic-gradient(#f3f4f6 0% 25%, #e5e7eb 0% 50%) 50% / 20px 20px;
 }
+
+#cropArea {
+  position: relative;
+  aspect-ratio: 1 / 1;
+  min-height: 280px;
+}
+
+#cropArea::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: repeating-conic-gradient(#f3f4f6 0% 25%, #e5e7eb 0% 50%) 50% / 24px 24px;
+  z-index: 0;
+}
+
+#cropArea > * {
+  position: relative;
+  z-index: 1;
+}
+
+#cropArea img {
+  max-width: 100%;
+  max-height: 100%;
+  height: auto;
+  display: block;
+}


### PR DESCRIPTION
## Summary
- remove the hue adjustment control from the UI and associated logic
- ensure the saturation slider reaches true grayscale at the minimum value
- introduce a patterned placeholder so the crop area is visible before loading an image

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_b_68e355b16c88833186120d1c8520ebe7