### PR TITLE
Restore filesystem background template loading

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -178,10 +178,15 @@
       const runningFromFile = window.location.protocol === 'file:';
 
       if (!isDataUrl) {
-        // Quando rodamos localmente (file://) o canvas é contaminado se desenharmos
-        // a imagem direto. Para contornar isso, convertemos para Blob e usamos
-        // um ObjectURL, que mantém a exportação habilitada.
-        shouldForceBlob = isFileUrl || runningFromFile;
+        if (isFileUrl) {
+          // Imagens locais (file://) não podem ser buscadas via fetch/XMLHttpRequest.
+          // Carregamos diretamente e confiamos na verificação de contaminação.
+          shouldForceBlob = false;
+        } else {
+          // Convertemos para Blob sempre que houver risco de CORS ou quando
+          // estivermos rodando via file:// e a origem for remota.
+          shouldForceBlob = !sameOrigin || runningFromFile;
+        }
       }
 
       shouldRequestCors = !isDataUrl && !isFileUrl && !sameOrigin;


### PR DESCRIPTION
## Summary
- remove the injected offline asset bundle and rely on the existing PNG template file
- point the theme configuration back to the PNG background and adjust image loading logic for local file URLs
- keep the canvas export safeguards for remote assets while allowing filesystem templates to load normally

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68e35db6ce08833189a615e484220ddb