### PR TITLE
Fix local file background loading without embedded data URL

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -168,6 +168,7 @@
     let objectUrl = null;
     let shouldRequestCors = false;
     let shouldForceBlob = false;
+    let shouldSetCrossOrigin = false;
 
     try {
       const resolvedUrl = new URL(url, window.location.href);
@@ -190,6 +191,7 @@
       }
 
       shouldRequestCors = !isDataUrl && !isFileUrl && !sameOrigin;
+      shouldSetCrossOrigin = shouldRequestCors;
     } catch (error) {
       // Mantém a URL original caso não seja possível resolvê-la (ex.: caminhos relativos não padrão).
       finalUrl = url;
@@ -270,7 +272,9 @@
 
     return new Promise((resolve, reject) => {
       const image = new Image();
-      image.crossOrigin = 'anonymous';
+      if (shouldSetCrossOrigin) {
+        image.crossOrigin = 'anonymous';
+      }
 
       image.onload = () => {
         if (objectUrl) {
@@ -334,8 +338,7 @@
    * problemáticas para evitar repetição de erros.
    */
   async function getBackgroundImage(url) {
-    if (!url) return null;
-    if (blockedBgUrls.has(url)) {
+    if (!url || blockedBgUrls.has(url)) {
       return null;
     }
     if (cachedBgImage && cachedBgUrl === url) {


### PR DESCRIPTION
## Summary
- load background images without forcing cross-origin mode when running from file:// to avoid CORS failures
- simplify background caching logic now that there is only a single configured URL
- restore the theme configuration so the background image path remains an external asset instead of an embedded data URL

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68e361d3e01083319a4bc4941d36fe5d