### PR TITLE
Remove unused logo URL and gradient fallback settings

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -390,7 +390,6 @@
 
     ctx.clearRect(0, 0, W, H);
 
-    let backgroundDrawn = false;
     if (THEME.bgUrl) {
       const bg = await getBackgroundImage(THEME.bgUrl);
       if (bg) {
@@ -398,9 +397,7 @@
         const bw = bg.width * scale;
         const bh = bg.height * scale;
         ctx.drawImage(bg, (W - bw) / 2, (H - bh) / 2, bw, bh);
-        if (canvasIsExportable(ctx)) {
-          backgroundDrawn = true;
-        } else {
+        if (!canvasIsExportable(ctx)) {
           console.warn('Fundo removido para evitar contaminação do canvas e permitir exportação.');
           blockedBgUrls.add(THEME.bgUrl);
           cachedBgImage = null;
@@ -408,14 +405,6 @@
           ctx.clearRect(0, 0, W, H);
         }
       }
-    }
-
-    if (!backgroundDrawn) {
-      const grad = ctx.createLinearGradient(0, 0, W, H);
-      grad.addColorStop(0, THEME.accent);
-      grad.addColorStop(1, THEME.accent2);
-      ctx.fillStyle = grad;
-      ctx.fillRect(0, 0, W, H);
     }
 
     const overlayOpacity =

--- a/theme.js
+++ b/theme.js
@@ -5,11 +5,6 @@ window.THEME = {
 
   // Referências visuais opcionais
   bgUrl: './template-teste-ixforum.png', // imagem de fundo em alta resolução
-  logoUrl: '', // logo do evento com transparência (PNG/SVG)
-
-  // Paleta principal (utilizada como degradê quando não há imagem de fundo)
-  accent: '#0B3E91',
-  accent2: '#1E88E5',
   textOnDark: '#ffffff',
   overlayOpacity: 0,
 


### PR DESCRIPTION
## Summary
- remove the unused logo URL and accent color settings from the theme configuration
- drop the gradient fallback so only the background template is used when available

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68e365d3d5d083318bfc3db4e668343a