### PR TITLE
Ensure Adobe Elza font loads for canvas preview

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -7,7 +7,7 @@
 }
 
 :root {
-  font-family: InterVar, system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, 'Helvetica Neue', Arial;
+  font-family: 'Elza', InterVar, system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, 'Helvetica Neue', Arial;
 }
 
 /* Preview compacto, sem scroll próprio */


### PR DESCRIPTION
## Summary
- preload and cache the Adobe Elza font weights used by the canvas renderer so the exported image uses the right typography
- trigger a redraw after the font loads and prioritize Elza in the global UI font stack

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68f1504ea4e48331bf8ad78777e13311